### PR TITLE
Call exec with list of arguments, avoiding shell expansion

### DIFF
--- a/lib/isolated_server/base.rb
+++ b/lib/isolated_server/base.rb
@@ -61,7 +61,7 @@ module IsolatedServer
             STDERR.reopen(devnull)
           end
 
-          exec(cmd)
+          exec(*cmd)
         end
 
         # begin waiting for the parent (or mysql) to die; at_exit is hard to control when interacting with test/unit
@@ -105,9 +105,6 @@ module IsolatedServer
     end
 
     def exec_server(cmd)
-      cmd.strip!
-      cmd.gsub!(/\\\n/, ' ')
-
       @pid = self.class.exec_wait(cmd, allow_output: @allow_output, parent_pid: @parent_pid) do |child_pid|
         Process.kill("KILL", child_pid)
         cleanup!

--- a/lib/isolated_server/base.rb
+++ b/lib/isolated_server/base.rb
@@ -61,7 +61,7 @@ module IsolatedServer
             STDERR.reopen(devnull)
           end
 
-          exec(*cmd)
+          exec(cmd)
         end
 
         # begin waiting for the parent (or mysql) to die; at_exit is hard to control when interacting with test/unit

--- a/lib/isolated_server/mongodb.rb
+++ b/lib/isolated_server/mongodb.rb
@@ -24,7 +24,7 @@ module IsolatedServer
         '--dbpath', @dbpath,
         '--port', @port,
         *@params
-      ].shelljoin)
+      ])
 
       until up?
         sleep(0.1)

--- a/lib/isolated_server/mongodb.rb
+++ b/lib/isolated_server/mongodb.rb
@@ -24,7 +24,7 @@ module IsolatedServer
         '--dbpath', @dbpath,
         '--port', @port,
         *@params
-      ])
+      ].join(' '))
 
       until up?
         sleep(0.1)

--- a/lib/isolated_server/mysql.rb
+++ b/lib/isolated_server/mysql.rb
@@ -80,7 +80,7 @@ module IsolatedServer
         @log_bin,
         '--log-slave-updates',
         *@params
-      ].shelljoin)
+      ])
 
       sleep(0.1) until up?
     end

--- a/lib/isolated_server/mysql.rb
+++ b/lib/isolated_server/mysql.rb
@@ -80,7 +80,7 @@ module IsolatedServer
         @log_bin,
         '--log-slave-updates',
         *@params
-      ])
+      ].join(' '))
 
       sleep(0.1) until up?
     end


### PR DESCRIPTION
Related to how `exec` expected behavior: http://ruby-doc.org/core-2.2.0/Kernel.html#method-i-exec

In the old behavior (calling it with a string), the pid obtained was of the shell, instead of the invoked command. That caused the script to not properly kill the running mysqld process.

From what @gabetax and I tested, it seems Mac OS `sh -c`, when executed with one command, replaces the shell process with the command. With more than one command, it behaves like Ubuntu.

Tested mysql isolated server in Ubuntu e Mac Os, both seem to work fine. This might break if somewhere exec_server is being called with arguments that need escaping.

/cc @gabetax @osheroff 