### PR TITLE
mysqld prints out full argv[0] path, so can't match regex with ^

### DIFF
--- a/lib/isolated_server/mysql.rb
+++ b/lib/isolated_server/mysql.rb
@@ -129,8 +129,8 @@ module IsolatedServer
         system("rm -f #{@mysql_data_dir.shellescape}/relay-log.info")
       else
         mysqld = locate_executable("mysqld")
-        `#{mysqld} --version` =~ /^mysqld\s+Ver (5\.\d)\.\d+/
-        major_version = $1
+        `#{mysqld} --version` =~ /mysqld\s+Ver (5\.\d)\.\d+/
+        major_version = $1 || '5.5'
 
         mysql_install_db = locate_executable("mysql_install_db")
 


### PR DESCRIPTION
Whoops, I didn't do that last change quite right. mysqld --version outputs the full path, so you can't match `/^mysqld.../`

@gabetax 