### PR TITLE
Use explicit basedir for mysql_install_db

### DIFF
--- a/lib/isolated_server/mysql.rb
+++ b/lib/isolated_server/mysql.rb
@@ -132,10 +132,13 @@ module IsolatedServer
         `#{mysqld} --version` =~ /mysqld\s+Ver (5\.\d)\.\d+/
         major_version = $1 || '5.5'
 
+        `#{mysqld} --no-defaults --verbose --help` =~ /^basedir\s+(.*)$/
+        basedir = $1
+
         mysql_install_db = locate_executable("mysql_install_db")
 
         idb_path = File.dirname(mysql_install_db)
-        system("(cd #{idb_path.shellescape}/..; mysql_install_db --datadir=#{@mysql_data_dir.shellescape} --user=`whoami`) >/dev/null 2>&1")
+        system("(cd #{idb_path.shellescape}/..; mysql_install_db --datadir=#{@mysql_data_dir.shellescape} --basedir=#{basedir.shellescape} --user=`whoami`) >/dev/null 2>&1")
         system("cp #{File.expand_path(File.dirname(__FILE__)).shellescape}/mysql/tables/#{major_version}/user.* #{@mysql_data_dir.shellescape}/mysql")
       end
     end


### PR DESCRIPTION
@gabetax @osheroff 

The implicit basedir doesn't work when mysql is installed via homebrew. In my case, `ibd_path` is `/usr/local/bin/` while `basedir` is `/usr/local/Cellar/mysql/5.6.23/`.